### PR TITLE
Backport changes from Helm Chart for Varnish Enterprise v1.5.0

### DIFF
--- a/varnish-cache/templates/_helpers.tpl
+++ b/varnish-cache/templates/_helpers.tpl
@@ -33,7 +33,7 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Sets up the Varnish Enterprise image and its overrides (if any)
+Sets up the Varnish Cache image and its overrides (if any)
 */}}
 {{- define "varnish-cache.image" }}
 {{- $base := .base | default dict }}
@@ -56,5 +56,41 @@ Sets extra envs from either an array, an object, or a string.
 {{- end }}
 {{- else if eq $tp "slice" }}
 {{- .envs | toYaml }}
+{{- end }}
+{{- end }}
+
+{{/*
+Declares the YAML field.
+*/}}
+{{- define "varnish-cache.toYamlField" }}
+{{- $section := default "server" .section }}
+{{- $fieldName := .fieldName }}
+{{- $fieldKey := default $fieldName .fieldKey }}
+{{- $fieldValue := (get .Values $section) }}
+{{- if (not (empty .subsection)) }}
+{{- $fieldValue = (get $fieldValue .subsection) }}
+{{- end }}
+{{- $fieldValue = (get $fieldValue $fieldKey) }}
+{{- if (empty $fieldValue) }}
+{{- $fieldValue = (dict) }}
+{{- else if eq (kindOf $fieldValue) "string" }}
+{{- $fieldValue = (fromYaml (tpl $fieldValue .)) }}
+{{- end }}
+{{- $globalFieldValue := (get .Values.global $fieldKey) }}
+{{- if eq (kindOf $globalFieldValue) "string" }}
+{{- $globalFieldValue = (fromYaml (tpl $globalFieldValue .)) }}
+{{- end }}
+{{- if not (empty $globalFieldValue) }}
+{{- $fieldValue = (merge $fieldValue $globalFieldValue) }}
+{{- end }}
+{{- $extraFieldValues := .extraFieldValues }}
+{{- if eq (kindOf $extraFieldValues) "string" }}
+{{- $extraFieldValues = (fromYaml (tpl $extraFieldValues .)) }}
+{{- end }}
+{{- if not (empty $extraFieldValues) }}
+{{- $fieldValue = (merge $fieldValue $extraFieldValues) }}
+{{- end }}
+{{- if not (empty $fieldValue) }}
+{{- (dict $fieldName $fieldValue) | toYaml }}
 {{- end }}
 {{- end }}

--- a/varnish-cache/templates/_helpers.tpl
+++ b/varnish-cache/templates/_helpers.tpl
@@ -41,3 +41,20 @@ Sets up the Varnish Enterprise image and its overrides (if any)
 image: "{{- if eq $image.repository "-" -}}{{ $base.repository }}{{ else }}{{ $image.repository }}{{ end }}:{{- if eq $image.tag "-" }}{{ default .Chart.AppVersion $base.tag }}{{ else }}{{ default $.Chart.AppVersion $image.tag }}{{ end }}"
 imagePullPolicy: {{ if eq $image.pullPolicy "-" }}{{ $base.pullPolicy }}{{ else }}{{ $image.pullPolicy }}{{ end }}
 {{- end }}
+
+{{/*
+Sets extra envs from either an array, an object, or a string.
+*/}}
+{{- define "varnish-cache.toEnv" }}
+{{- $tp := kindOf .envs }}
+{{- if eq $tp "string" }}
+{{- tpl .envs . | trim | nindent 0 }}
+{{- else if eq $tp "map" }}
+{{- range $k, $v := .envs }}
+- name: {{ $k | quote }}
+  value: {{ $v | quote }}
+{{- end }}
+{{- else if eq $tp "slice" }}
+{{- .envs | toYaml }}
+{{- end }}
+{{- end }}

--- a/varnish-cache/templates/_metadata.tpl
+++ b/varnish-cache/templates/_metadata.tpl
@@ -37,7 +37,7 @@ Sets up the common server extra annotations
 {{- define "varnish-cache.serverAnnotations" -}}
 {{- if .Values.server.annotations }}
 annotations:
-  {{- $tp := typeOf .Values.server.annotations }}
+  {{- $tp := kindOf .Values.server.annotations }}
   {{- if eq $tp "string" }}
     {{- tpl .Values.server.annotations . | trim | nindent 2 }}
   {{- else }}
@@ -51,7 +51,7 @@ Sets up the common server extra labels
 */}}
 {{- define "varnish-cache.serverLabels" -}}
 {{- if .Values.server.labels }}
-{{- $tp := typeOf .Values.server.labels }}
+{{- $tp := kindOf .Values.server.labels }}
 {{- if eq $tp "string" }}
   {{- tpl .Values.server.labels . | trim | nindent 0 }}
 {{- else }}
@@ -66,7 +66,7 @@ Sets up the common service extra annotations
 {{- define "varnish-cache.serviceAnnotations" -}}
 {{- if .Values.server.service.annotations }}
 annotations:
-  {{- $tp := typeOf .Values.server.service.annotations }}
+  {{- $tp := kindOf .Values.server.service.annotations }}
   {{- if eq $tp "string" }}
     {{- tpl .Values.server.service.annotations . | trim | nindent 2 }}
   {{- else }}
@@ -82,7 +82,7 @@ Sets up the common service extra labels
 {{- $section := default "server" .section -}}
 {{- $service := (get .Values $section).service -}}
 {{- if $service.labels -}}
-{{- $tp := typeOf $service.labels -}}
+{{- $tp := kindOf $service.labels -}}
 {{- if eq $tp "string" -}}
 {{- tpl $service.labels . | trim | nindent 0 }}
 {{- else -}}
@@ -99,7 +99,7 @@ Sets up the common ingress extra annotations
 {{- $ingress := (get .Values $section).ingress -}}
 {{- if $ingress.annotations }}
 annotations:
-  {{- $tp := typeOf $ingress.annotations }}
+  {{- $tp := kindOf $ingress.annotations }}
   {{- if eq $tp "string" }}
     {{- tpl $ingress.annotations . | trim | nindent 2 }}
   {{- else }}
@@ -115,7 +115,7 @@ Sets up the common ingress extra labels
 {{- $section := default "server" .section -}}
 {{- $ingress := (get .Values $section).ingress -}}
 {{- if $ingress.labels }}
-{{- $tp := typeOf $ingress.labels }}
+{{- $tp := kindOf $ingress.labels }}
 {{- if eq $tp "string" }}
   {{- tpl $ingress.labels . | trim | nindent 0 }}
 {{- else }}
@@ -130,7 +130,7 @@ Sets up the common service account annotations
 {{- define "varnish-cache.serviceAccountAnnotations" -}}
 {{- if .Values.serviceAccount.annotations }}
 annotations:
-  {{- $tp := typeOf .Values.serviceAccount.annotations }}
+  {{- $tp := kindOf .Values.serviceAccount.annotations }}
   {{- if eq $tp "string" }}
     {{- tpl .Values.serviceAccount.annotations . | trim | nindent 2 }}
   {{- else }}
@@ -144,7 +144,7 @@ Sets up the common service account extra labels
 */}}
 {{- define "varnish-cache.serviceAccountLabels" -}}
 {{- if .Values.serviceAccount.labels }}
-{{- $tp := typeOf .Values.serviceAccount.labels }}
+{{- $tp := kindOf .Values.serviceAccount.labels }}
 {{- if eq $tp "string" }}
   {{- tpl .Values.serviceAccount.labels . | trim | nindent 0 }}
 {{- else }}

--- a/varnish-cache/templates/_metadata.tpl
+++ b/varnish-cache/templates/_metadata.tpl
@@ -35,29 +35,34 @@ Create the name of the service account to use
 Sets up the common server extra annotations
 */}}
 {{- define "varnish-cache.serverAnnotations" -}}
-{{- if .Values.server.annotations }}
-annotations:
-  {{- $tp := kindOf .Values.server.annotations }}
-  {{- if eq $tp "string" }}
-    {{- tpl .Values.server.annotations . | trim | nindent 2 }}
-  {{- else }}
-    {{- toYaml .Values.server.annotations | nindent 2 }}
-  {{- end }}
-{{- end }}
+{{- $section := default "server" .section }}
+{{- include "varnish-cache.toYamlField"
+  (merge
+    (dict
+      "section" $section
+      "fieldName" "annotations"
+      "extraFieldValues" .extraAnnotations)
+    .) }}
 {{- end }}
 
 {{/*
 Sets up the common server extra labels
 */}}
 {{- define "varnish-cache.serverLabels" -}}
-{{- if .Values.server.labels }}
-{{- $tp := kindOf .Values.server.labels }}
-{{- if eq $tp "string" }}
-  {{- tpl .Values.server.labels . | trim | nindent 0 }}
-{{- else }}
-  {{- toYaml .Values.server.labels | nindent 0 }}
+{{- $section := default "server" .section }}
+{{- $nameSuffix := .nameSuffix }}
+{{- if not (eq $nameSuffix "") }}
+{{- $nameSuffix = .section }}
 {{- end }}
-{{- end }}
+{{- $defaultLabel := (fromYaml (include "varnish-cache.labels" (merge (dict "nameSuffix" $nameSuffix) .))) }}
+{{- $extraLabels := default dict .extraLabels }}
+{{- include "varnish-cache.toYamlField"
+  (merge
+    (dict
+      "section" $section
+      "fieldName" "labels"
+      "extraFieldValues" (merge $extraLabels $defaultLabel))
+    .) }}
 {{- end }}
 
 {{/*
@@ -151,4 +156,113 @@ Sets up the common service account extra labels
   {{- toYaml .Values.serviceAccount.labels | nindent 0 }}
 {{- end }}
 {{- end }}
+{{- end }}
+
+
+{{/*
+Declares the Pod's serviceAccount.
+*/}}
+{{- define "varnish-cache.podServiceAccount" }}
+serviceAccountName: {{ include "varnish-cache.serviceAccountName" . }}
+{{- end }}
+{{/*
+Declares the Pod's securityContext.
+*/}}
+{{- define "varnish-cache.podSecurityContext" }}
+{{- if not (empty .Values.global.podSecurityContext) }}
+securityContext:
+  {{- toYaml .Values.global.podSecurityContext | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Sets up Pod labels
+*/}}
+{{- define "varnish-cache.podLabels" }}
+{{- $section := default "server" .section }}
+{{- $nameSuffix := .nameSuffix }}
+{{- if not (eq $nameSuffix "") }}
+{{- $nameSuffix = .section }}
+{{- end }}
+{{- $defaultLabel := (fromYaml (include "varnish-cache.selectorLabels" (merge (dict "nameSuffix" $nameSuffix) .))) }}
+{{- $extraLabels := default dict .extraLabels }}
+{{- include "varnish-cache.toYamlField"
+  (merge
+    (dict
+      "section" $section
+      "fieldName" "labels"
+      "fieldKey" "podLabels"
+      "extraFieldValues" (merge $extraLabels $defaultLabel))
+    .) }}
+{{- end }}
+
+{{/*
+Declares the Varnish deployment strategy
+*/}}
+{{- define "varnish-cache.strategy" -}}
+{{- if .Values.server.strategy }}
+{{- $tp := kindOf .Values.server.strategy }}
+strategy:
+{{- if eq $tp "string" }}
+  {{- tpl .Values.server.strategy . | trim | nindent 2 }}
+{{- else }}
+  {{- toYaml .Values.server.strategy | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Declares the Varnish DaemonSet and StatefulSet updateStrategy
+*/}}
+{{- define "varnish-cache.updateStrategy" -}}
+{{- if .Values.server.updateStrategy }}
+{{- $tp := kindOf .Values.server.updateStrategy }}
+updateStrategy:
+{{- if eq $tp "string" }}
+  {{- tpl .Values.server.updateStrategy . | trim | nindent 2 }}
+{{- else }}
+  {{- toYaml .Values.server.updateStrategy | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Sets up nodeSelector depending on whether a YAML map or a string is given.
+*/}}
+{{- define "varnish-cache.nodeSelector" -}}
+{{- if .Values.server.nodeSelector }}
+nodeSelector:
+  {{- $tp := kindOf .Values.server.nodeSelector }}
+  {{- if eq $tp "string" }}
+    {{- tpl .Values.server.nodeSelector . | trim | nindent 2 }}
+  {{- else }}
+    {{- toYaml .Values.server.nodeSelector | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Declares the container securityContext.
+*/}}
+{{- define "varnish-cache.securityContext" }}
+{{- include "varnish-cache.toYamlField"
+  (merge
+    (dict
+      "section" .section
+      "subsection" .subsection
+      "fieldName" "securityContext")
+    .) }}
+{{- end }}
+
+{{/*
+Declares the container resource.
+*/}}
+{{- define "varnish-cache.resources" }}
+{{- include "varnish-cache.toYamlField"
+  (merge
+    (dict
+      "section" .section
+      "subsection" .subsection
+      "fieldName" "resources")
+    .) }}
 {{- end }}

--- a/varnish-cache/templates/_pod.tpl
+++ b/varnish-cache/templates/_pod.tpl
@@ -4,7 +4,7 @@ Sets up nodeSelector depending on whether a YAML map or a string is given.
 {{- define "varnish-cache.nodeSelector" -}}
 {{- if .Values.server.nodeSelector }}
 nodeSelector:
-  {{- $tp := typeOf .Values.server.nodeSelector }}
+  {{- $tp := kindOf .Values.server.nodeSelector }}
   {{- if eq $tp "string" }}
     {{- tpl .Values.server.nodeSelector . | trim | nindent 2 }}
   {{- else }}
@@ -20,7 +20,7 @@ Sets up Pod labels
 labels:
   {{- include "varnish-cache.selectorLabels" . | nindent 2 }}
   {{- if .Values.server.podLabels }}
-  {{- $tp := typeOf .Values.server.podLabels }}
+  {{- $tp := kindOf .Values.server.podLabels }}
   {{- if eq $tp "string" }}
     {{- tpl .Values.server.podLabels . | trim | nindent 2 }}
   {{- else }}
@@ -39,7 +39,7 @@ Sets up Pod annotations
 {{- $secretConfig := include "varnish-cache.secretConfig" . }}
 annotations:
   {{- if .Values.server.podAnnotations }}
-  {{- $tp := typeOf .Values.server.podAnnotations }}
+  {{- $tp := kindOf .Values.server.podAnnotations }}
   {{- if eq $tp "string" }}
     {{- tpl .Values.server.podAnnotations . | trim | nindent 2 }}
   {{- else }}
@@ -65,7 +65,7 @@ annotations:
   {{- if not (empty $extraManifests) }}
   {{- range $v := $extraManifests }}
   {{- if default false $v.checksum }}
-  {{- $tp := typeOf $v.data }}
+  {{- $tp := kindOf $v.data }}
   {{- if eq $tp "string" }}
   checksum/{{ $.Release.Name }}-extra-{{ $v.name }}: {{ tpl $v.data $ | sha256sum }}
   {{- else }}
@@ -82,7 +82,7 @@ Sets up Pod affinity depending on whether a YAML map or a string is given.
 {{- define "varnish-cache.affinity" -}}
 {{- if .Values.server.affinity }}
 affinity:
-  {{- $tp := typeOf .Values.server.affinity }}
+  {{- $tp := kindOf .Values.server.affinity }}
   {{- if eq $tp "string" }}
     {{- tpl .Values.server.affinity . | trim | nindent 2 }}
   {{- else }}
@@ -97,7 +97,7 @@ Sets up Pod tolerations depending on whether a YAML map or a string is given.
 {{- define "varnish-cache.tolerations" -}}
 {{- if .Values.server.tolerations }}
 tolerations:
-  {{- $tp := typeOf .Values.server.tolerations }}
+  {{- $tp := kindOf .Values.server.tolerations }}
   {{- if eq $tp "string" }}
     {{- tpl .Values.server.tolerations . | trim | nindent 2 }}
   {{- else }}
@@ -194,7 +194,7 @@ volumes:
   emptyDir:
     medium: "Memory"
 {{- if .Values.server.extraVolumes }}
-  {{- $tp := typeOf .Values.server.extraVolumes }}
+  {{- $tp := kindOf .Values.server.extraVolumes }}
   {{- if eq $tp "string" }}
     {{- tpl .Values.server.extraVolumes . | trim | nindent 0 }}
   {{- else }}
@@ -237,7 +237,7 @@ Declares the Varnish Cache container
 {{- define "varnish-cache.serverContainer" -}}
 {{- $cmdfileConfig := include "varnish-cache.cmdfileConfig" . }}
 {{- $defaultVcl := osBase .Values.server.vclConfigPath }}
-{{- $tp := typeOf .Values.server.extraArgs }}
+{{- $tp := kindOf .Values.server.extraArgs }}
 {{- $varnishExtraArgs := list }}
 {{- if eq $tp "string" }}
 {{- $varnishExtraArgs = append $varnishExtraArgs .Values.server.extraArgs }}
@@ -391,7 +391,7 @@ Declares the Varnish Cache container
     - name: {{ .Release.Name }}-varnish-vsm
       mountPath: /var/lib/varnish
     {{- if .Values.server.extraVolumeMounts }}
-    {{- $tp := typeOf .Values.server.extraVolumeMounts }}
+    {{- $tp := kindOf .Values.server.extraVolumeMounts }}
     {{- if eq $tp "string" }}
     {{- tpl .Values.server.extraVolumeMounts . | trim | nindent 4 }}
     {{- else }}
@@ -467,7 +467,7 @@ Declares the Varnish deployment strategy
 */}}
 {{- define "varnish-cache.strategy" -}}
 {{- if .Values.server.strategy }}
-{{- $tp := typeOf .Values.server.strategy }}
+{{- $tp := kindOf .Values.server.strategy }}
 strategy:
 {{- if eq $tp "string" }}
   {{- tpl .Values.server.strategy . | trim | nindent 2 }}
@@ -482,7 +482,7 @@ Declares the Varnish DaemonSet and StatefulSet updateStrategy
 */}}
 {{- define "varnish-cache.updateStrategy" -}}
 {{- if .Values.server.updateStrategy }}
-{{- $tp := typeOf .Values.server.updateStrategy }}
+{{- $tp := kindOf .Values.server.updateStrategy }}
 updateStrategy:
 {{- if eq $tp "string" }}
   {{- tpl .Values.server.updateStrategy . | trim | nindent 2 }}
@@ -497,7 +497,7 @@ Declares the Varnish extra container
 */}}
 {{- define "varnish-cache.extraContainers" -}}
 {{- if .Values.server.extraContainers }}
-{{- $tp := typeOf .Values.server.extraContainers }}
+{{- $tp := kindOf .Values.server.extraContainers }}
 {{- if eq $tp "string" }}
   {{- tpl .Values.server.extraContainers . | trim | nindent 0 }}
 {{- else }}
@@ -512,7 +512,7 @@ Declares the Varnish init containers
 {{- define "varnish-cache.initContainers" -}}
 {{- if .Values.server.extraInitContainers }}
 initContainers:
-  {{- $tp := typeOf .Values.server.extraInitContainers }}
+  {{- $tp := kindOf .Values.server.extraInitContainers }}
   {{- if eq $tp "string" }}
     {{- tpl .Values.server.extraInitContainers . | trim | nindent 2 }}
   {{- else }}

--- a/varnish-cache/templates/_pod.tpl
+++ b/varnish-cache/templates/_pod.tpl
@@ -357,6 +357,7 @@ Declares the Varnish Cache container
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    {{- include "varnish-cache.toEnv" (merge (dict "envs" .Values.server.extraEnvs) .) | nindent 4 }}
   volumeMounts:
     - name: {{ .Release.Name }}-config
       mountPath: /etc/varnish

--- a/varnish-cache/templates/daemonset.yaml
+++ b/varnish-cache/templates/daemonset.yaml
@@ -9,10 +9,8 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "varnish-cache.fullname" . }}
-  labels:
-    {{- include "varnish-cache.labels" . | nindent 4 }}
-    {{- include "varnish-cache.serverLabels" . | indent 4 }}
-  {{- include "varnish-cache.serverAnnotations" . | indent 2 }}
+  {{- include "varnish-cache.serverLabels" . | nindent 2 }}
+  {{- include "varnish-cache.serverAnnotations" . | nindent 2 }}
 spec:
   {{- include "varnish-cache.updateStrategy" . | indent 2 }}
   selector:
@@ -20,8 +18,8 @@ spec:
       {{- include "varnish-cache.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- include "varnish-cache.podLabels" . | indent 6 }}
-      {{- include "varnish-cache.podAnnotations" . | indent 6 }}
+      {{- include "varnish-cache.podLabels" . | nindent 6 }}
+      {{- include "varnish-cache.podAnnotations" . | nindent 6 }}
     spec:
       {{- include "varnish-cache.podImagePullSecrets" . | indent 6 }}
       {{- include "varnish-cache.podServiceAccount" . | indent 6 }}

--- a/varnish-cache/templates/deployment.yaml
+++ b/varnish-cache/templates/deployment.yaml
@@ -9,10 +9,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "varnish-cache.fullname" . }}
-  labels:
-    {{- include "varnish-cache.labels" . | nindent 4 }}
-    {{- include "varnish-cache.serverLabels" . | indent 4 }}
-  {{- include "varnish-cache.serverAnnotations" . | indent 2 }}
+  {{- include "varnish-cache.serverLabels" . | nindent 2 }}
+  {{- include "varnish-cache.serverAnnotations" . | nindent 2 }}
 spec:
   {{- if not .Values.server.autoscaling.enabled }}
   replicas: {{ .Values.server.replicas }}
@@ -23,8 +21,8 @@ spec:
       {{- include "varnish-cache.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- include "varnish-cache.podLabels" . | indent 6 }}
-      {{- include "varnish-cache.podAnnotations" . | indent 6 }}
+      {{- include "varnish-cache.podLabels" . | nindent 6 }}
+      {{- include "varnish-cache.podAnnotations" . | nindent 6 }}
     spec:
       {{- include "varnish-cache.podImagePullSecrets" . | indent 6 }}
       {{- include "varnish-cache.podServiceAccount" . | indent 6 }}

--- a/varnish-cache/templates/extra.yaml
+++ b/varnish-cache/templates/extra.yaml
@@ -3,7 +3,7 @@
 {{- range $v := $extraManifests }}
 ---
 # Name: {{ $v.name }}
-{{- $tp := typeOf $v.data }}
+{{- $tp := kindOf $v.data }}
 {{- if eq $tp "string" }}
 {{ tpl $v.data $ }}
 {{- else }}

--- a/varnish-cache/templates/hpa.yaml
+++ b/varnish-cache/templates/hpa.yaml
@@ -30,7 +30,7 @@ spec:
 {{- end }}
 {{- if .Values.server.autoscaling.metrics }}
   metrics:
-{{- $tp := typeOf .Values.server.autoscaling.metrics }}
+{{- $tp := kindOf .Values.server.autoscaling.metrics }}
 {{- if eq $tp "string" }}
   {{- tpl .Values.server.autoscaling.metrics . | trim | nindent 4 }}
 {{- else }}

--- a/varnish-cache/templates/statefulset.yaml
+++ b/varnish-cache/templates/statefulset.yaml
@@ -6,10 +6,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "varnish-cache.fullname" . }}
-  labels:
-    {{- include "varnish-cache.labels" . | nindent 4 }}
-    {{- include "varnish-cache.serverLabels" . | indent 4 }}
-  {{- include "varnish-cache.serverAnnotations" . | indent 2 }}
+  {{- include "varnish-cache.serverLabels" . | nindent 2 }}
+  {{- include "varnish-cache.serverAnnotations" . | nindent 2 }}
 spec:
   serviceName: {{ include "varnish-cache.fullname" . }}
   {{- if not .Values.server.autoscaling.enabled }}
@@ -21,8 +19,8 @@ spec:
       {{- include "varnish-cache.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- include "varnish-cache.podLabels" . | indent 6 }}
-      {{- include "varnish-cache.podAnnotations" . | indent 6 }}
+      {{- include "varnish-cache.podLabels" . | nindent 6 }}
+      {{- include "varnish-cache.podAnnotations" . | nindent 6 }}
     spec:
       {{- include "varnish-cache.podImagePullSecrets" . | indent 6 }}
       {{- include "varnish-cache.podServiceAccount" . | indent 6 }}

--- a/varnish-cache/templates/statefulset.yaml
+++ b/varnish-cache/templates/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
       {{- include "varnish-cache.terminationGracePeriodSeconds" . | indent 6 }}
   {{- if not (empty .Values.server.extraVolumeClaimTemplates) }}
   volumeClaimTemplates:
-    {{- $tp := typeOf .Values.server.extraVolumeClaimTemplates }}
+    {{- $tp := kindOf .Values.server.extraVolumeClaimTemplates }}
     {{- if eq $tp "string" }}
       {{- tpl .Values.server.extraVolumeClaimTemplates . | trim | nindent 4 }}
     {{- else }}

--- a/varnish-cache/test/unit_common/common.bats
+++ b/varnish-cache/test/unit_common/common.bats
@@ -77,7 +77,78 @@ template=${template:-}
 
     # Note: values.yaml has 'global.securityContext.runAsNonRoot=true' as the default;
     # we're testing that the values are merged and not replaced.
-    [ "${actual}" == '{"hello":"world","runAsNonRoot":true,"runAsUser":1000,"foo":"bar"}' ]
+    [ "${actual}" == '{"foo":"bar","hello":"world","runAsNonRoot":true,"runAsUser":1000}' ]
+}
+
+@test "${kind}: inherits securityContext from global and server with global as a templated string" {
+    cd "$(chart_dir)"
+
+    local securityContext="
+release-name: {{ .Release.Name }}
+release-namespace: {{ .Release.Namespace }}
+"
+
+    local actual=$((helm template \
+        --set "server.kind=${kind}" \
+        --set "global.securityContext=${securityContext}" \
+        --set 'server.securityContext.runAsUser=1000' \
+        --set 'server.securityContext.foo=bar' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") | tee -a /dev/stderr |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
+            .securityContext' | tee -a /dev/stderr)
+
+    [ "${actual}" == '{"foo":"bar","release-name":"release-name","release-namespace":"default","runAsUser":1000}' ]
+}
+
+@test "${kind}: inherits securityContext from global and server with server as a templated string" {
+    cd "$(chart_dir)"
+
+    local securityContext="
+release-name: {{ .Release.Name }}
+release-namespace: {{ .Release.Namespace }}
+"
+
+    local actual=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'global.securityContext.hello=world' \
+        --set "server.securityContext=${securityContext}" \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") | tee -a /dev/stderr |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
+            .securityContext' | tee -a /dev/stderr)
+
+    # Note: values.yaml has 'global.securityContext.runAsNonRoot=true' as the default;
+    # we're testing that the values are merged and not replaced.
+    [ "${actual}" == '{"hello":"world","release-name":"release-name","release-namespace":"default","runAsNonRoot":true,"runAsUser":999}' ]
+}
+
+@test "${kind}: inherits securityContext from global and server with both as a templated string" {
+    cd "$(chart_dir)"
+
+    local securityContext="
+release-name: {{ .Release.Name }}
+release-namespace: to-be-override
+"
+
+    local actual=$((helm template \
+        --set "server.kind=${kind}" \
+        --set "global.securityContext=${securityContext}" \
+        --set 'server.securityContext=release-namespace: {{ .Release.Namespace }}' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") | tee -a /dev/stderr |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
+            .securityContext' | tee -a /dev/stderr)
+
+    # Note: values.yaml has 'global.securityContext.runAsNonRoot=true' as the default;
+    # we're testing that the values are merged and not replaced.
+    [ "${actual}" == '{"release-name":"release-name","release-namespace":"default"}' ]
 }
 
 @test "${kind}: inherits labels from server" {
@@ -164,32 +235,71 @@ template=${template:-}
     [ "${actual}" == "release-name" ]
 }
 
-@test "${kind}: inherits podLabels from server" {
+@test "${kind}: inherits podLabels from global and server" {
     cd "$(chart_dir)"
 
-    local actual=$((helm template \
+    local object=$((helm template \
         --set "server.kind=${kind}" \
+        --set 'global.podLabels.foo=bar' \
         --set 'server.podLabels.hello=varnish' \
         --namespace default \
         --show-only ${template} \
-        . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.labels.hello' |
+        . || echo "---") |
+        tee -a /dev/stderr)
+
+    local actual=$(echo "$object" |
+        yq -r -c '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
-    [ "${actual}" == "varnish" ]
+
+    [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-cache","foo":"bar","hello":"varnish"}' ]
 }
 
-@test "${kind}: inherits podLabels from server as templated string" {
+@test "${kind}: inherits podLabels from global and server with global as templated string" {
     cd "$(chart_dir)"
 
-    local actual=$((helm template \
+    local labels="
+release-name: {{ .Release.Name }}
+release-namespace: to-be-override
+"
+
+    local object=$((helm template \
         --set "server.kind=${kind}" \
-        --set 'server.podLabels=hello: {{ .Release.Name }}' \
+        --set "global.podLabels=${labels}" \
+        --set 'server.podLabels.release-namespace=varnish' \
         --namespace default \
         --show-only ${template} \
-        . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.labels.hello' |
+        . || echo "---") |
+        tee -a /dev/stderr)
+
+    local actual=$(echo "$object" |
+        yq -r -c '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
-    [ "${actual}" == "release-name" ]
+
+    [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-cache","release-name":"release-name","release-namespace":"varnish"}' ]
+}
+
+@test "${kind}: inherits podLabels from global and server with server as templated string" {
+    cd "$(chart_dir)"
+
+    local labels="
+release-name: {{ .Release.Name }}
+release-namespace: {{ .Release.Namespace }}
+"
+
+    local object=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'global.podLabels.release-namespace=to-be-override' \
+        --set "server.podLabels=${labels}" \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") |
+        tee -a /dev/stderr)
+
+    local actual=$(echo "$object" |
+        yq -r -c '.spec.template.metadata.labels' |
+            tee -a /dev/stderr)
+
+    [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-cache","release-name":"release-name","release-namespace":"default"}' ]
 }
 
 @test "${kind}: inherits default selector labels" {
@@ -2079,15 +2189,100 @@ vcl.use vcl_main
     [ "${actual}" == "null" ]
 }
 
-@test "${kind}/resources: can be configured" {
+@test "${kind}/resources: inherits resources from global and server" {
     cd "$(chart_dir)"
 
     local actual=$((helm template \
         --set "server.kind=${kind}" \
+        --set 'global.resources.limits.cpu=100m' \
+        --set 'global.resources.requests.cpu=100m' \
         --set 'server.resources.limits.cpu=500m' \
         --set 'server.resources.limits.memory=512Mi' \
-        --set 'server.resources.requests.cpu=100m' \
         --set 'server.resources.requests.memory=128Mi' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") | tee -a /dev/stderr |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
+            .resources' | tee -a /dev/stderr)
+
+    [ "${actual}" == '{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}' ]
+}
+
+@test "${kind}/resources: inherits resources from global and server with global as a templated string" {
+    cd "$(chart_dir)"
+
+    local resources="
+limits:
+  cpu: 500m
+  memory: 512Mi
+requests:
+  memory: 128Mi
+"
+
+    local actual=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'global.resources.limits.cpu=100m' \
+        --set 'global.resources.requests.cpu=100m' \
+        --set "server.resources=${resources}" \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") | tee -a /dev/stderr |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
+            .resources' | tee -a /dev/stderr)
+
+    [ "${actual}" == '{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}' ]
+}
+
+@test "${kind}/resources: inherits resources from global and server with server as a templated string" {
+    cd "$(chart_dir)"
+
+    local resources="
+limits:
+  cpu: 100m
+requests:
+  cpu: 100m
+"
+
+    local actual=$((helm template \
+        --set "server.kind=${kind}" \
+        --set "global.resources=${resources}" \
+        --set 'server.resources.limits.cpu=500m' \
+        --set 'server.resources.limits.memory=512Mi' \
+        --set 'server.resources.requests.memory=128Mi' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") | tee -a /dev/stderr |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
+            .resources' | tee -a /dev/stderr)
+
+    [ "${actual}" == '{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}' ]
+}
+
+@test "${kind}/resources: inherits resources from global and server with both as a templated string" {
+    cd "$(chart_dir)"
+
+    local globalResources="
+limits:
+  cpu: 100m
+requests:
+  cpu: 100m
+"
+
+    local resources="
+limits:
+  cpu: 500m
+  memory: 512Mi
+requests:
+  memory: 128Mi
+"
+
+    local actual=$((helm template \
+        --set "server.kind=${kind}" \
+        --set "global.resources=${globalResources}" \
+        --set "server.resources=${resources}" \
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
@@ -2375,8 +2570,7 @@ podAntiAffinity:
     local actual=$((helm template \
         --set "server.kind=${kind}" \
         --set 'global.securityContext.hello=world' \
-        --set 'server.securityContext.runAsUser=1000' \
-        --set 'server.securityContext.foo=bar' \
+        --set 'server.securityContext.ignore-this=yes' \
         --set 'server.varnishncsa.securityContext.runAsUser=1001' \
         --set 'server.varnishncsa.securityContext.foo=baz' \
         --namespace default \
@@ -2388,7 +2582,87 @@ podAntiAffinity:
 
     # Note: values.yaml has 'global.securityContext.runAsNonRoot=true' as the default;
     # we're testing that the values are merged and not replaced.
-    [ "${actual}" == '{"hello":"world","runAsNonRoot":true,"runAsUser":1001,"foo":"baz"}' ]
+    [ "${actual}" == '{"foo":"baz","hello":"world","runAsNonRoot":true,"runAsUser":1001}' ]
+}
+
+@test "${kind}/varnishncsa: inherits securityContext from global and varnishncsa with global as a templated string" {
+    cd "$(chart_dir)"
+
+    local securityContext="
+release-name: {{ .Release.Name }}
+release-namespace: {{ .Release.Namespace }}
+"
+
+    local actual=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'server.varnishncsa.enabled=true' \
+        --set 'server.secret=hello-varnish' \
+        --set "global.securityContext=${securityContext}" \
+        --set 'server.securityContext.ignore-this=yes' \
+        --set 'server.varnishncsa.securityContext.runAsUser=1001' \
+        --set 'server.varnishncsa.securityContext.foo=baz' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") | tee -a /dev/stderr |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
+            .securityContext' | tee -a /dev/stderr)
+
+    [ "${actual}" == '{"foo":"baz","release-name":"release-name","release-namespace":"default","runAsUser":1001}' ]
+}
+
+@test "${kind}/varnishncsa: inherits securityContext from global and varnishncsa with varnishncsa as a templated string" {
+    cd "$(chart_dir)"
+
+    local securityContext="
+release-name: {{ .Release.Name }}
+release-namespace: {{ .Release.Namespace }}
+"
+
+    local actual=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'server.varnishncsa.enabled=true' \
+        --set 'server.secret=hello-varnish' \
+        --set 'global.securityContext.hello=world' \
+        --set 'server.securityContext.ignore-this=yes' \
+        --set "server.varnishncsa.securityContext=${securityContext}" \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") | tee -a /dev/stderr |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
+            .securityContext' | tee -a /dev/stderr)
+
+    # Note: values.yaml has 'global.securityContext.runAsNonRoot=true' as the default;
+    # we're testing that the values are merged and not replaced.
+    [ "${actual}" == '{"hello":"world","release-name":"release-name","release-namespace":"default","runAsNonRoot":true,"runAsUser":999}' ]
+}
+
+@test "${kind}/varnishncsa: inherits securityContext from global and varnishncsa with both as a templated string" {
+    cd "$(chart_dir)"
+
+    local securityContext="
+release-name: {{ .Release.Name }}
+release-namespace: to-be-override
+"
+
+    local actual=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'server.varnishncsa.enabled=true' \
+        --set 'server.secret=hello-varnish' \
+        --set "global.securityContext=${securityContext}" \
+        --set 'server.securityContext.ignore-this=yes' \
+        --set 'server.varnishncsa.securityContext=release-namespace: {{ .Release.Namespace }}' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") | tee -a /dev/stderr |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
+            .securityContext' | tee -a /dev/stderr)
+
+    # Note: values.yaml has 'global.securityContext.runAsNonRoot=true' as the default;
+    # we're testing that the values are merged and not replaced.
+    [ "${actual}" == '{"release-name":"release-name","release-namespace":"default"}' ]
 }
 
 @test "${kind}/varnishncsa/extraArgs: can be configured" {
@@ -2614,6 +2888,51 @@ podAntiAffinity:
             .resources' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
+}
+
+@test "${kind}/varnishncsa/extraVolumeMounts: can be configured" {
+    cd "$(chart_dir)"
+
+    local object=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'server.varnishncsa.extraVolumeMounts[0].name=varnish-data' \
+        --set 'server.varnishncsa.extraVolumeMounts[0].mountPath=/var/data' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") |
+        tee -a /dev/stderr)
+
+    local actual=$(echo "$object" |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
+            .volumeMounts[]? | select(.name == "varnish-data")' |
+            tee -a /dev/stderr)
+
+    [ "${actual}" == '{"mountPath":"/var/data","name":"varnish-data"}' ]
+}
+
+@test "${kind}/varnishncsa/extraVolumeMounts: can be configured as templated string" {
+    cd "$(chart_dir)"
+
+    local extraVolumeMounts="
+- name: {{ .Release.Name }}-data
+  mountPath: /var/data"
+
+    local object=$((helm template \
+        --set "server.kind=${kind}" \
+        --set "server.varnishncsa.extraVolumeMounts=${extraVolumeMounts}" \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") |
+        tee -a /dev/stderr)
+
+    local actual=$(echo "$object" |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
+            .volumeMounts[]? | select(.name == "release-name-data")' |
+            tee -a /dev/stderr)
+
+    [ "${actual}" == '{"name":"release-name-data","mountPath":"/var/data"}' ]
 }
 
 @test "${kind}/extraManifests: do nothing with templated string without checksum flag" {

--- a/varnish-cache/values.yaml
+++ b/varnish-cache/values.yaml
@@ -110,6 +110,9 @@ server:
   #    mode: "0700"
   #    proto: "PROXY"
 
+  # Sets the extra environment variables for Varnish Enterprise.
+  extraEnvs: {}
+
   # Sets the default Time To Live (TTL) for cached objects.
   ttl: 120
 

--- a/varnish-cache/values.yaml
+++ b/varnish-cache/values.yaml
@@ -20,6 +20,28 @@ global:
     runAsUser: 999
     runAsNonRoot: true
 
+  # Sets the annotations for all workload resources.
+  annotations: {}
+
+  # Sets the annotations for all pod templates.
+  podAnnotations: {}
+
+  # Sets the labels for all workload resources.
+  labels: {}
+
+  # Sets the labels for all pod templates.
+  podLabels: {}
+
+  # Configures a resource limits for all containers.
+  resources: {}
+  #resources:
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -110,8 +132,25 @@ server:
   #    mode: "0700"
   #    proto: "PROXY"
 
-  # Sets the extra environment variables for Varnish Enterprise.
+  # Sets the extra environment variables for Varnish Cache. Can be set as either
+  # an object, a list, or a templated string.
   extraEnvs: {}
+  #extraEnvs:
+  #  MY_ENV_VAR: value
+  #  MY_OTHER_ENV_VAR: other_value
+  #
+  #extraEnvs:
+  #  - name: MY_ENV_VAR
+  #    value: value
+  #  - name: MY_OTHER_ENV_VAR
+  #    valueFrom:
+  #      configMapRef:
+  #        name: my-config-map
+  #        value: my-key
+  #
+  #extraEnvs: |
+  #  - name: RELEASE_NAMESPACE
+  #    value: {{ .Release.Namespace }}
 
   # Sets the default Time To Live (TTL) for cached objects.
   ttl: 120
@@ -548,7 +587,7 @@ server:
       # Sets the consecutive failures until a probe is considered a failure.
       failureThreshold: 3
 
-    # Configures a resource limits.
+    # Configures a resource limits for Varnish NCSA container.
     resources: {}
     #resources:
     #  limits:


### PR DESCRIPTION
- Allow settings extraEnvs
- Replaced typeOf with kindOf
- Consolidate annotations and labels to use field helper