### PR TITLE
Wait for connection to drain with delayedShutdown

### DIFF
--- a/varnish-cache/values.yaml
+++ b/varnish-cache/values.yaml
@@ -288,7 +288,33 @@ server:
   #cmdfileConfigFile: "files/cmds.cli"
 
   # Delays stopping of the Varnish Cache container by the given seconds.
-  delayedHaltSeconds: 0
+  # Deprecated: use `server.delayedShutdown` instead
+  #delayedHaltSeconds: 0
+
+  # Configures delayed shutdown for zero-downtime downscaling.
+  delayedShutdown:
+    # Delayed shutdown method. Can be one of:
+    #
+    #     none      Do not perform delayed shutdown
+    #     sleep     Perform sleep in preStop for specific seconds
+    #     mempool   Automatically determine if there is any active clients before shutting down
+    #
+    # Note that when this value is set to anything other than "none"
+    # `server.terminationGracePeriodSeconds` must also be set to the
+    # maximum time it takes for Varnish Cache to shutdown.
+    method: "none"
+
+    # Configures "sleep" delayed shutdown method.
+    sleep:
+      seconds: 90
+
+    # Configures "mempool" delayed shutdown method.
+    mempool:
+      # Poll the mempool session every given pollSeconds.
+      pollSeconds: 1
+
+      # Wait for the given waitSeconds before fully shutting down.
+      waitSeconds: 5
 
   # Sets the image and tag to use to deploy Varnish Cache.
   # If tag is blank, appVersion is used.


### PR DESCRIPTION
Closes #9

Change to allow user to configure "delayed shutdown" in preStop base on sleep seconds or polling MEMPOOL via varnishstat. This is to allow zero-downtime during scaledown (e.g. replicas 3 -> 2) where Varnish may still continue to receive a new connection until after load balancer is reconciled with endpoint.

Mempool code is based on #8