### PR TITLE
Use varnish-cache's default VCL instead of providing the default

### DIFF
--- a/varnish-cache/README.md
+++ b/varnish-cache/README.md
@@ -34,7 +34,16 @@ Varnish Cache Helm Chart is designed to be highly configurable while requiring m
 
 #### Changing the default VCL
 
-By default, Varnish Cache Helm Chart provides an empty VCL with a default backend configured to `locahost:8080`. In most cases, this needs to be changed to something more useful. To do so with the values override, configure `server.vclConfig` as needed:
+Varnish Cache Helm Chart does not provide any VCL by default. Instead, it uses the default VCL located at `/etc/varnish/default.vcl` provided within the Docker image. From varnish:7.5.0 onward, it is possible to configure the default backend via an environment variable:
+
+```yaml
+server:
+  extraEnvs:
+    VARNISH_BACKEND_HOST: "localhost"
+    VARNISH_BACKEND_PORT: "8080"
+```
+
+If a more advanced customization is required, it is also possible to override the default VCL with `server.vclConfig`:
 
 ```yaml
 ---

--- a/varnish-cache/templates/_pod.tpl
+++ b/varnish-cache/templates/_pod.tpl
@@ -105,9 +105,11 @@ Declares the Pod's volume mounts.
 {{- define "varnish-cache.podVolumes" }}
 {{- $defaultVcl := osBase .Values.server.vclConfigPath }}
 volumes:
+{{- if or (not (empty .Values.server.vclConfig)) (not (empty .Values.server.vclConfigs)) }}
 - name: {{ .Release.Name }}-config
   emptyDir:
     medium: "Memory"
+{{- end }}
 {{- if and (not (empty .Values.server.secretFrom)) (not (eq .Values.server.secret "")) }}
 {{- fail "Either 'server.secret' or 'server.secretFrom' can be set." }}
 {{- else if and (not (empty .Values.server.secretFrom)) }}
@@ -265,6 +267,9 @@ Declares the Varnish Cache container
     {{- if not (eq (include "varnish-cache.vclConfig" .) "") }}
     - -f
     - {{ .Values.server.vclConfigPath }}
+    {{- else }}
+    - -f
+    - /etc/varnish/default.vcl
     {{- end }}
     {{- if .Values.server.admin.port }}
     - -T
@@ -302,8 +307,10 @@ Declares the Varnish Cache container
           fieldPath: status.podIP
     {{- include "varnish-cache.toEnv" (merge (dict "envs" .Values.server.extraEnvs) .) | nindent 4 }}
   volumeMounts:
+    {{- if or (not (empty .Values.server.vclConfig)) (not (empty .Values.server.vclConfigs)) }}
     - name: {{ .Release.Name }}-config
       mountPath: /etc/varnish
+    {{- end }}
     {{- if and (not (empty .Values.server.secretFrom)) (hasKey .Values.server.secretFrom "name") (hasKey .Values.server.secretFrom "key") }}
     - name: {{ .Release.Name }}-config-secret
       mountPath: /etc/varnish/secret

--- a/varnish-cache/values.yaml
+++ b/varnish-cache/values.yaml
@@ -244,13 +244,7 @@ server:
   vclConfigPath: "/etc/varnish/default.vcl"
 
   # Configures the default VCL. Can be set as a templated string.
-  vclConfig: |
-    vcl 4.1;
-
-    backend default {
-      .host = "127.0.0.1";
-      .port = "8080";
-    }
+  vclConfig: ""
 
   # Use the content of the given file path as VCL configuration. The file will be
   # parsed as templated string. Will override "server.vclConfig" if set. Note that


### PR DESCRIPTION
Closes #3

The default VCL in the varnish-cache Docker image allows configuring the backend via an environment variable. By allowing this VCL to be used, we can ensure the way to configure the Helm chart is consistent with a plain Docker.

See also https://github.com/varnish/docker-varnish/pull/73