### PR TITLE
Make get-latest-tag retrieve non-suffix tags by default

### DIFF
--- a/scripts/get-latest-tag.sh
+++ b/scripts/get-latest-tag.sh
@@ -63,7 +63,7 @@ if [ $# -lt 1 ]; then
 fi
 
 REPO=$1; shift
-FILTER=${1:-"[0-9]+\."}
+FILTER=${1:-"[0-9]+\.[0-9\.]+$"}
 
 skopeo list-tags "$REPO" |
     jq -r '.Tags[]' |


### PR DESCRIPTION
Closes #14

Because version comparison in get-latest-tag always prioritizes suffixed tags (e.g., -alpine) over the ones without, this caused -alpine to be used as the default appVersion during build.