### PR TITLE
Fix regression introduced by optional vclConfig

### DIFF
--- a/varnish-cache/templates/_pod.tpl
+++ b/varnish-cache/templates/_pod.tpl
@@ -264,7 +264,7 @@ Declares the Varnish Cache container
     - -a
     - http=$(VARNISH_HTTP_ADDRESS):{{ .Values.server.http.port }},HTTP
     {{- end }}
-    {{- if not (eq (include "varnish-cache.vclConfig" .) "") }}
+    {{- if or (not (eq (include "varnish-cache.vclConfig" .) "")) (not (empty .Values.server.extraVolumeMounts)) }}
     - -f
     - {{ .Values.server.vclConfigPath }}
     {{- else }}

--- a/varnish-cache/templates/_pod.tpl
+++ b/varnish-cache/templates/_pod.tpl
@@ -259,13 +259,8 @@ Declares the Varnish Cache container
     - -a
     - http=$(VARNISH_HTTP_ADDRESS):{{ .Values.server.http.port }},HTTP
     {{- end }}
-    {{- if or (not (eq (include "varnish-cache.vclConfig" .) "")) (not (empty .Values.server.extraVolumeMounts)) }}
     - -f
     - {{ .Values.server.vclConfigPath }}
-    {{- else }}
-    - -f
-    - /etc/varnish/default.vcl
-    {{- end }}
     {{- if .Values.server.admin.port }}
     - -T
     - {{ .Values.server.admin.address }}:{{ .Values.server.admin.port }}

--- a/varnish-cache/templates/_pod.tpl
+++ b/varnish-cache/templates/_pod.tpl
@@ -105,11 +105,6 @@ Declares the Pod's volume mounts.
 {{- define "varnish-cache.podVolumes" }}
 {{- $defaultVcl := osBase .Values.server.vclConfigPath }}
 volumes:
-{{- if or (not (empty .Values.server.vclConfig)) (not (empty .Values.server.vclConfigs)) }}
-- name: {{ .Release.Name }}-config
-  emptyDir:
-    medium: "Memory"
-{{- end }}
 {{- if and (not (empty .Values.server.secretFrom)) (not (eq .Values.server.secret "")) }}
 {{- fail "Either 'server.secret' or 'server.secretFrom' can be set." }}
 {{- else if and (not (empty .Values.server.secretFrom)) }}
@@ -307,10 +302,6 @@ Declares the Varnish Cache container
           fieldPath: status.podIP
     {{- include "varnish-cache.toEnv" (merge (dict "envs" .Values.server.extraEnvs) .) | nindent 4 }}
   volumeMounts:
-    {{- if or (not (empty .Values.server.vclConfig)) (not (empty .Values.server.vclConfigs)) }}
-    - name: {{ .Release.Name }}-config
-      mountPath: /etc/varnish
-    {{- end }}
     {{- if and (not (empty .Values.server.secretFrom)) (hasKey .Values.server.secretFrom "name") (hasKey .Values.server.secretFrom "key") }}
     - name: {{ .Release.Name }}-config-secret
       mountPath: /etc/varnish/secret

--- a/varnish-cache/test/unit_common/common.bats
+++ b/varnish-cache/test/unit_common/common.bats
@@ -1315,11 +1315,6 @@ release-namespace: {{ .Release.Namespace }}
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '' ]
-
-    local actual=$(echo "$object" |
         yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
@@ -1334,11 +1329,6 @@ release-namespace: {{ .Release.Namespace }}
             .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/default.vcl"]' ]
-
-    local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '' ]
 
     local actual=$(echo "$container" |
         yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
@@ -1379,11 +1369,6 @@ backend release-name {
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","emptyDir":{"medium":"Memory"}}' ]
-
-    local actual=$(echo "$object" |
         yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-cache-vcl"}}' ]
@@ -1398,11 +1383,6 @@ backend release-name {
             .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/default.vcl"]' ]
-
-    local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","mountPath":"/etc/varnish"}' ]
 
     local actual=$(echo "$container" |
         yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
@@ -1444,11 +1424,6 @@ backend release-name {
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","emptyDir":{"medium":"Memory"}}' ]
-
-    local actual=$(echo "$object" |
         yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-cache-vcl"}}' ]
@@ -1463,11 +1438,6 @@ backend release-name {
             .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/default.vcl"]' ]
-
-    local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","mountPath":"/etc/varnish"}' ]
 
     local actual=$(echo "$container" |
         yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
@@ -1530,11 +1500,6 @@ backend release-name {
     [ "${actual}" = '11060980fc16de8bee3d626bfa600a13ab5db83471fd93fe60e15437f2d568b5' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","emptyDir":{"medium":"Memory"}}' ]
-
-    local actual=$(echo "$object" |
         yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-cache-vcl"}}' ]
@@ -1554,16 +1519,6 @@ backend release-name {
             .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/default.vcl"]' ]
-
-    local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","emptyDir":{"medium":"Memory"}}' ]
-
-    local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","mountPath":"/etc/varnish"}' ]
 
     local actual=$(echo "$container" |
         yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
@@ -1632,11 +1587,6 @@ backend release-name {
     [ "${actual}" = '11060980fc16de8bee3d626bfa600a13ab5db83471fd93fe60e15437f2d568b5' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","emptyDir":{"medium":"Memory"}}' ]
-
-    local actual=$(echo "$object" |
         yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-cache-vcl"}}' ]
@@ -1656,11 +1606,6 @@ backend release-name {
             .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/default.vcl"]' ]
-
-    local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","mountPath":"/etc/varnish"}' ]
 
     local actual=$(echo "$container" |
         yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
@@ -1730,11 +1675,6 @@ backend release-name {
     [ "${actual}" = '11060980fc16de8bee3d626bfa600a13ab5db83471fd93fe60e15437f2d568b5' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","emptyDir":{"medium":"Memory"}}' ]
-
-    local actual=$(echo "$object" |
         yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-cache-vcl"}}' ]
@@ -1754,11 +1694,6 @@ backend release-name {
             .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/varnish.vcl"]' ]
-
-    local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","mountPath":"/etc/varnish"}' ]
 
     local actual=$(echo "$container" |
         yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
@@ -1862,11 +1797,6 @@ backend default {
             .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-f","/etc/varnish/varnish.vcl"]' ]
-
-    local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config")' |
-            tee -a /dev/stderr)
-    [ "${actual}" = '{"name":"release-name-config","mountPath":"/etc/varnish"}' ]
 
     local actual=$(echo "$container" |
         yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |


### PR DESCRIPTION
The recent introduction of optional `server.vclConfig` caused a few regressions (oops) which this PR fixes:

- Fixed `server.vclConfigPath` can no longer be set if `server.vclConfig` is empty but `server.vclConfigs` is not; this is now taken in an account. It's still undecided at this point whether to allow setting `server.vclConfigPath` without checking `server.vclConfig`/`server.vclConfigs`. 
- When specifying `server.vclConfigs` without specifying `server.vclConfig`, the `/etc/varnish` emptydir also gets mounted when it shouldn't. This is fixed by completely removing `/etc/varnish` mount, as they're not really used for anything anyway. All VCLs are already mounted as an individual file, and trying to use `/etc/varnish` shared mount without mounting other files will result in a zero-byte file being displayed instead, which leads to further confusion.

Will do some extra testing before releasing a fix as v1.1.1. 