### PR TITLE
Revamp podSelector for netpol

### DIFF
--- a/varnish-cache/templates/networkpolicy.yaml
+++ b/varnish-cache/templates/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "varnish-cache.name" . }}
+      {{- include "varnish-cache.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
     - Egress

--- a/varnish-cache/templates/networkpolicy.yaml
+++ b/varnish-cache/templates/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ .Release.Name }}
   policyTypes:
     - Ingress
     - Egress

--- a/varnish-cache/templates/networkpolicy.yaml
+++ b/varnish-cache/templates/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: varnish
+      app.kubernetes.io/name: {{ include "varnish-cache.name" . }}
   policyTypes:
     - Ingress
     - Egress

--- a/varnish-cache/templates/networkpolicy.yaml
+++ b/varnish-cache/templates/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/name: varnish
   policyTypes:
     - Ingress
     - Egress


### PR DESCRIPTION
instance is too global, the goal is simply to restrict it to varnish pods